### PR TITLE
[feat] isAllday, isOrigin 필드 추가 및 로직 수정

### DIFF
--- a/src/events/dto/request/CreateEventDto.ts
+++ b/src/events/dto/request/CreateEventDto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsDateString, IsOptional } from 'class-validator';
+import { IsString, IsDateString, IsOptional, IsBoolean } from 'class-validator';
 
 export class CreateEventDto {
   @ApiProperty({ example: '썬더치킨 정모', description: 'Event title' })
@@ -24,4 +24,18 @@ export class CreateEventDto {
   @IsOptional() // 필수X
   @IsString()
   memo?: string;
+
+  @ApiProperty({
+    example: false,
+    description: 'Is the event all-day (true) or specific time (false)',
+  })
+  @IsBoolean()
+  isAllday: boolean;
+
+  @ApiProperty({
+    example: false,
+    description: 'Is the event from user data (false) or public data (true)',
+  })
+  @IsBoolean()
+  isOrigin: boolean;
 }

--- a/src/events/entities/event.entity.ts
+++ b/src/events/entities/event.entity.ts
@@ -7,6 +7,7 @@ export class Event {
 
   @Column()
   title: string;
+
   @Column()
   startDate: string;
 
@@ -15,4 +16,10 @@ export class Event {
 
   @Column({ nullable: true })
   memo?: string;
+
+  @Column()
+  isOrigin: boolean;
+
+  @Column()
+  isAllday: boolean;
 }

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -13,6 +13,12 @@ export class EventService {
 
   // 이벤트 생성
   async create(createEventDto: CreateEventDto): Promise<Event> {
+    if (createEventDto.isAllday) {
+      // 하루 종일인 경우, 시간 제거
+      createEventDto.startDate = createEventDto.startDate.split('T')[0];
+      createEventDto.endDate = createEventDto.endDate.split('T')[0];
+    }
+
     const event = this.eventRepository.create(createEventDto);
     return this.eventRepository.save(event);
   }


### PR DESCRIPTION
## Summary
*한 줄 설명*
- 이벤트 entity와 createventdto에 isAllday, isOrigin 필드 추가
- 추가된 필드로 서비스 수정
- - isAllday가 true 이면 시간 제거

## Description
- *어떤 코드가 추가/변경 됐는지*
-

## Screenshots
*실행 결과 스크린샷*
<img width="287" alt="스크린샷 2025-04-02 오후 12 05 37" src="https://github.com/user-attachments/assets/00889f4d-3971-454b-b07c-458982910e39" />


## Test Checklist
- [ ] *테스트할 사람이 어떤 것을 확인하면 좋을지*
- [ ] 
